### PR TITLE
chore: issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,20 @@
+---
+name: Bug Report
+about: Report a bug encountered while using the falcoctl
+labels: kind/bug
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+
+If the matter is security related, please disclose it privately via https://falco.org/security/
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,11 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to the Falco project
+labels: kind/feature
+
+---
+<!-- Please only use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why is this needed**:

--- a/.github/ISSUE_TEMPLATE/failing-tests.md
+++ b/.github/ISSUE_TEMPLATE/failing-tests.md
@@ -1,0 +1,20 @@
+---
+name: Failing Test
+about: Report test failures in Falco CI jobs
+labels: kind/failing-test
+
+---
+
+<!-- Please only use this template for submitting reports about failing tests in Falco CI jobs -->
+
+**Which jobs are failing**:
+
+**Which test(s) are failing**:
+
+**Since when has it been failing**:
+
+**Test link**:
+
+**Reason for failure**:
+
+**Anything else we need to know**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,64 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+
+1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
+2. Please label this pull request according to what type of issue you are addressing.
+3. Please add a release note!
+4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
+-->
+
+**What type of PR is this?**
+
+> Uncomment one (or more) `/kind <>` lines:
+
+> /kind bug
+
+> /kind cleanup
+
+> /kind design
+
+> /kind documentation
+
+> /kind failing-test
+
+> /kind feature
+
+> /kind flaky-test
+
+**Any specific area of the project related to this PR?**
+
+> Uncomment one (or more) `/area <>` lines:
+
+> /area api
+
+> /area client
+
+> /area tests
+
+> /area examples
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+
+<!--
+Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
+-->
+
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Does this PR introduce a user-facing change?**:
+
+<!--
+If no, just write "NONE" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
+For example, `action required: change the API interface of the rule engine`.
+-->
+
+```release-note
+
+```


### PR DESCRIPTION
This PR introduces issue and PR templates for the client-go repository.

It proposes the following areas:
- api
- client
- tests
- examples

And the following kind to mark issues/PRs:
- bug
- cleanup
- design
- documentation
- failing-test
- feature
- flaky-test

Please feel free to propose changes or new area/kind labels.

Fixes #3 

Also notice that this PR is WIP because, once we all agree, we need to create `area/*` and `kind/*` labels manually before to merge this PR.

/kind documentation

```release-note
NONE
```