### PR TITLE
build: make protos must be the default makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ PROTO_SHAS := a1f427c114b945d0880b55058862b74015d036aa722985ca6e5474ab4ed19f69 2
 PROTO_DIRS := $(dir ${PROTOS})
 PROTO_DIRS_INCLUDES := $(patsubst %/, -I %, ${PROTO_DIRS})
 
+.PHONY: protos
+protos: ${PROTOS}
+
 # $(1): the proto path
 # $(2): the proto URL
 # $(3): the proto SHA256
@@ -25,9 +28,6 @@ $(foreach PROTO,$(PROTOS),\
 	$(eval PROTO_URLS := $(wordlist 2,$(words $(PROTO_URLS)),$(PROTO_URLS)))\
 	$(eval PROTO_SHAS := $(wordlist 2,$(words $(PROTO_SHAS)),$(PROTO_SHAS)))\
 )
-
-.PHONY: protos
-protos: ${PROTOS}
 
 .PHONY: clean
 clean: ${PROTO_DIRS}


### PR DESCRIPTION

**What type of PR is this?**

/kind bug



**What this PR does / why we need it**:

Makes the `protos` target of the makefile the default one so that calling `make` calls it.

**Which issue(s) this PR fixes**:


Fixes #25

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
