### PR TITLE
feat(pkg/client): add DialOptions and Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ go for the unix socket.
 package main
 
 imports(
+    "context"
     "github.com/falcosecurity/client-go/pkg/client"
 )
 
 func main() {
-    c, err := client.NewForConfig(&client.Config{
+    c, err := client.NewForConfig(context.Background(), &client.Config{
         Hostname:   "localhost",
         Port:       5060,
         CertFile:   "/etc/falco/certs/client.crt",
@@ -47,11 +48,12 @@ If you are binding the Falco gRPC server to unix socket, this is what you need.
 package main
 
 imports(
+    "context"
     "github.com/falcosecurity/client-go/pkg/client"
 )
 
 func main() {
-    c, err := client.NewForConfig(&client.Config{
+    c, err := client.NewForConfig(context.Background(), &client.Config{
         UnixSocketPath:   "unix:///var/run/falco.sock",
     })
 }
@@ -89,7 +91,7 @@ for {
 
 ```go
 // Set up a connection to the server.
-c, err := client.NewForConfig(&client.Config{
+c, err := client.NewForConfig(context.Background(), &client.Config{
     Hostname:   "localhost",
     Port:       5060,
     CertFile:   "/etc/falco/certs/client.crt",

--- a/examples/output/main.go
+++ b/examples/output/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	//Set up a connection to the server.
-	c, err := client.NewForConfig(&client.Config{
+	c, err := client.NewForConfig(context.Background(), &client.Config{
 		Hostname:   "localhost",
 		Port:       5060,
 		CertFile:   "/etc/falco/certs/client.crt",

--- a/examples/output_unix_socket/main.go
+++ b/examples/output_unix_socket/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	//Set up a connection to the server.
-	c, err := client.NewForConfig(&client.Config{
+	c, err := client.NewForConfig(context.Background(), &client.Config{
 		UnixSocketPath: "unix:///var/run/falco.sock",
 	})
 	if err != nil {

--- a/examples/version/main.go
+++ b/examples/version/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	// Set up a connection to the server.
-	c, err := client.NewForConfig(&client.Config{
+	c, err := client.NewForConfig(context.Background(), &client.Config{
 		Hostname:   "localhost",
 		Port:       5060,
 		CertFile:   "/etc/falco/certs/client.crt",

--- a/pkg/client/example_test.go
+++ b/pkg/client/example_test.go
@@ -14,7 +14,7 @@ import (
 // The simplest use of a Client, just create and Close it.
 func ExampleClient() {
 	//Set up a connection to the server.
-	c, err := client.NewForConfig(&client.Config{
+	c, err := client.NewForConfig(context.Background(), &client.Config{
 		Hostname:   "localhost",
 		Port:       5060,
 		CertFile:   "/etc/falco/certs/client.crt",
@@ -30,7 +30,7 @@ func ExampleClient() {
 // A client that is created and then used to Subscribe to Falco output events
 func ExampleClient_outputSubscribe() {
 	// Set up a connection to the server.
-	c, err := client.NewForConfig(&client.Config{
+	c, err := client.NewForConfig(context.Background(), &client.Config{
 		Hostname:   "localhost",
 		Port:       5060,
 		CertFile:   "/etc/falco/certs/client.crt",
@@ -68,7 +68,7 @@ func ExampleClient_outputSubscribe() {
 
 func ExampleClient_version() {
 	// Set up a connection to the server.
-	c, err := client.NewForConfig(&client.Config{
+	c, err := client.NewForConfig(context.Background(), &client.Config{
 		Hostname:   "localhost",
 		Port:       5060,
 		CertFile:   "/etc/falco/certs/client.crt",


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area api

/area client

> /area tests

> /area examples

**What this PR does / why we need it**:

This PR adds `DialOptions`  to `client.Config` struct and `Context` as parameter to `client.NewForConfig()`, allowing more control over gRPC connection options.

In particular, it allows configuration like:

```go
ctx, _ := context.WithTimeout(context.Background(), time.Minute*2)
client.NewForConfig(ctx, &client.Config{
	DialOptions: []grpc.DialOption{
		grpc.WithBlock(),
	},
	Context: ctx,
})
```

```go
config := &client.Config{
	DialOptions: []grpc.DialOption{
		grpc.WithDefaultCallOptions(
			grpc.WaitForReady(true),
		),
		grpc.WithBackoffMaxDelay(time.Minute),
	},
}
```

These settings are really useful to avoid to re-implement those functionalities on the consumer side like in [this attempt](https://github.com/falcosecurity/falco-exporter/pull/28).


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/cc @fntlnz 
/cc @leodido 

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
feat(pkg/client): add DialOptions and Context
```
