### PR TITLE
build: do not process source files when build and testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Protos
-          command: make protos
-      - run:
           name: Test
           command: make test
   release:

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ MOCKS := $(join $(dir ${MOCK_PROTOS}),$(patsubst %.proto,mocks/%.go,$(notdir ${M
 mocks: protos ${MOCKS}
 
 .PHONY: test
-test: mocks
+test:
 	@$(GO) vet ./...
 	@$(GO) test ${TEST_FLAGS} ./...
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

CI workflow should not process source files that are already under the VCS. Otherwise, we might not catch some mistakes like when mocks are missing but the testing is passing anyway (since the CI rebuilds them before running tests).


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/cc @leodido 

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
