### PR TITLE
update(falco/OWNERS): move inactive approvers to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,9 @@
 approvers:
   - leodido
   - leogr
+emeritus_approvers:
   - fntlnz
   - kris-nova
   - mfdii
   - markyjackson-taulia
-reviewers:
-  - leodido
-  - leogr
-  - fntlnz
-  - kris-nova
-  - mfdii
-  - markyjackson-taulia
+  


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

/area examples

**What this PR does / why we need it**:

For https://github.com/falcosecurity/evolution/issues/157, this PR moves inactive approvers (who had very little or zero contributions over the past 6 months) from `approvers` to `emeritus_approvers` in OWNERS.

Considering the low activity of this repository, devstats have also been consulted for the past year: https://falco.devstats.cncf.io/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=falcosecurity%2Fclient-go&var-country_name=All

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Opening this in place of #57, due to it being blocked and the reviewer requesting changes not responding.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
