### PR TITLE
gRPC authentication as an option

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -58,7 +58,6 @@ func newUnixSocketClient(ctx context.Context, config *Config) (*Client, error) {
 }
 
 func newNetworkClient(ctx context.Context, config *Config) (*Client, error) {  
-
 	certificate, err := tls.LoadX509KeyPair(
 		config.CertFile,
 		config.KeyFile,
@@ -96,10 +95,7 @@ func newNetworkClient(ctx context.Context, config *Config) (*Client, error) {
 	return &Client{
 		conn: conn,
 	}, nil
-	
 }
-
-
 
 // Outputs is the client for Falco Outputs.
 // When using it you can use `Sub()` or `Get()` to receive a stream of Falco output events.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -57,28 +57,21 @@ func newUnixSocketClient(ctx context.Context, config *Config) (*Client, error) {
 	}, nil
 }
 
-func newNetworkClient(ctx context.Context, config *Config) (*Client, error) {  //problem somewhere here
+func newNetworkClient(ctx context.Context, config *Config) (*Client, error) {  
 
 	certificate, err := tls.LoadX509KeyPair(
-		config.CertFile,	
-		config.KeyFile,		
+		config.CertFile,
+		config.KeyFile,
 	)
-
-
 	if err != nil {
 		return nil, fmt.Errorf("error loading the X.509 key pair: %v", err)
 	}
-
-	
 	if(config.GRPCAuth){
 		certPool := x509.NewCertPool()
 		rootCA, err := ioutil.ReadFile(config.CARootFile) 
-		
-
 		if err != nil {
 			return nil, fmt.Errorf("error reading the CA Root file certificate: %v", err)
 		}
-
 		ok := certPool.AppendCertsFromPEM(rootCA)
 		if !ok {
 			return nil, fmt.Errorf("error appending the root CA to the certificate pool")
@@ -89,13 +82,10 @@ func newNetworkClient(ctx context.Context, config *Config) (*Client, error) {  /
 			RootCAs:      certPool,
 		})
 		dialOptions := append(config.DialOptions, grpc.WithTransportCredentials(transportCreds))
-
 		conn, err := grpc.DialContext(ctx, fmt.Sprintf(targetFormat, config.Hostname, config.Port), dialOptions...) 
-
 		if err != nil {
 			return nil, fmt.Errorf("error dialing server: %v", err)
 		}
-
 		return &Client{
 			conn: conn,
 		}, nil
@@ -107,19 +97,13 @@ func newNetworkClient(ctx context.Context, config *Config) (*Client, error) {  /
 
 		})
 		dialOptions := append(config.DialOptions, grpc.WithTransportCredentials(transportCreds))
-
 		conn, err := grpc.DialContext(ctx, fmt.Sprintf(targetFormat, config.Hostname, config.Port), dialOptions...) 
-
 		if err != nil {
 			return nil, fmt.Errorf("error dialing server: %v", err)
 		}
-
 		return &Client{
 			conn: conn,
 		}, nil
-	
-
-
 }
 
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -72,7 +72,7 @@ func newNetworkClient(ctx context.Context, config *Config) (*Client, error) {  /
 	
 	if(config.GRPCAuth){
 		certPool := x509.NewCertPool()
-		rootCA, err := ioutil.ReadFile(config.CARootFile) //rootCA has correct value, at least translates into correct ascii; that doesnt happen w/ x509 however the values remain the same if you force them or not 
+		rootCA, err := ioutil.ReadFile(config.CARootFile) 
 		
 
 		if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -26,14 +26,14 @@ type Client struct {
 
 // Config is the configuration definition for connecting to a Falco gRPC server.
 type Config struct {
-	Hostname       					string
-	Port           					uint16
-	CertFile       					string
-	KeyFile        					string
-	CARootFile     					string
-	UnixSocketPath 					string
-	DialOptions    					[]grpc.DialOption
-	InsecureSkipMutualTLSAuth       bool
+	Hostname 			string
+	Port 				uint16
+	CertFile 			string
+	KeyFile 			string
+	CARootFile 			string
+	UnixSocketPath 			string
+	DialOptions 			[]grpc.DialOption
+	InsecureSkipMutualTLSAuth 	bool
 }
 
 const targetFormat = "%s:%d"
@@ -71,7 +71,7 @@ func newNetworkClient(ctx context.Context, config *Config) (*Client, error) {
 		InsecureSkipVerify: config.InsecureSkipMutualTLSAuth,
 	}
 	certPool := x509.NewCertPool()
-	if(!config.InsecureSkipMutualTLSAuth){
+	if !config.InsecureSkipMutualTLSAuth {
 		rootCA, err := ioutil.ReadFile(config.CARootFile)
 		if err != nil {
 			return nil, fmt.Errorf("error reading the CA Root file certificate: %v", err)


### PR DESCRIPTION
<!-- This is my first PR, so I'm not sure if I'm doing everything right :sweat_smile: I just made this feature for myself and thought to share it with the community!
 -->
Having problems with falco-exporter authentication to your gRPC server? Why should you have to deal with that?
Make authentication to gRPC an option with this simple trick! :smile: 
(it still requires a client certificate and key, but ignores them)

/kind feature

/area client

Note: this is deeply related to another PR I'll be creating for falco-exporter!

UPDATE: It's [this]( https://github.com/falcosecurity/falco-exporter/pull/90) PR!

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

